### PR TITLE
Add new keywords and break syntax file common highlight groups

### DIFF
--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -11,7 +11,7 @@ syntax keyword balIs is in
 syntax keyword balImport import returns return
 syntax keyword balObject object record
 syntax keyword balFunc resource worker init main
-syntax region balIOFunc start=/\vio:\(/ skip=/\v\\./ end=/\v\)/
+syntax match balFunctionCall "\zs\(\k\w*:\)*\(\k\w*\)*\s*\ze("
 syntax match balOperator "\v\*"
 syntax match balOperator "\v\|"
 syntax match balOperator "\v/"
@@ -37,7 +37,7 @@ highlight link balTypes Type
 highlight link balImport Identifier
 highlight link balObject Keyword
 highlight link balFunc Function
-highlight link balIOFunc Function
+highlight link balFunctionCall Function
 highlight link balComment Comment
 highlight link balString String
 highlight link balConditions Statement

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -36,8 +36,8 @@ syntax match balOperator "\v\+\="
 syntax match balOperator "\v-\="
 syntax match balOperator "\v\=[^\>]"
 syntax match balLabel    "\v\=\>"
-syntax match balLabel    "\v\<-"
-syntax match balLabel    "\v-\>"
+syntax match balLabel    "\v\<{1,2}-"
+syntax match balLabel    "\v-\>{1,2}"
 syntax region balString start=/\v"/ skip=/\v\\./ end=/\v"/
 syntax region balComment start=/\v(\/\/|#)/ skip=/\v\\./ end=/\v\_$/
 syntax match balNumber "\v<\d+>"

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -6,7 +6,7 @@ endif
 syntax keyword balModifiers public private external final remote const
 syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly
 syntax keyword balTypes function xmlns 
-syntax match balTypes "\v(xml|(\w*)):(Element|ProcessingInstruction|Comment)"
+syntax keyword balTypedef type
 syntax keyword balConditions if else while foreach for
 syntax keyword balIs is in 
 syntax keyword balImport import returns
@@ -14,6 +14,7 @@ syntax keyword balStatement return
 syntax keyword balObject object record
 syntax keyword balFunc resource worker
 syntax keyword balBoolean true false
+syntax match balTypes "\v(xml|(\w*)):(Element|ProcessingInstruction|Comment)"
 syntax match balFunctionCall "\zs\(\k\w*:\)*\(\k\w*\)*\s*\ze("
 syntax match balOperator "\v\*"
 syntax match balOperator "\v\|"
@@ -49,6 +50,7 @@ highlight def link balConditions Statement
 highlight def link balNumber Number
 highlight def link balStatement Statement
 highlight def link balBoolean Boolean
+highlight def link balTypedef Typedef
 
 " learn more about plugin dev - link - http://learnvimscriptthehardway.stevelosh.com/
 " learn about groups :help group-name

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -4,12 +4,14 @@ endif
 
 
 syntax keyword balModifiers public private external final remote const const
-syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var
+syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly
+syntax keyword balTypes function 
 syntax keyword balConditions if else while foreach for
 syntax keyword balIs is in 
 syntax keyword balImport import returns return
 syntax keyword balObject object record
-syntax keyword balFunc function resource worker
+syntax keyword balFunc resource worker init main
+syntax keyword balIOFunc "\vio:\*"
 syntax match balOperator "\v\*"
 syntax match balOperator "\v\|"
 syntax match balOperator "\v/"
@@ -35,6 +37,7 @@ highlight link balTypes Type
 highlight link balImport Identifier
 highlight link balObject Keyword
 highlight link balFunc Function
+highlight link balIOFunc Function
 highlight link balComment Comment
 highlight link balString String
 highlight link balConditions Statement

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -4,7 +4,7 @@ endif
 
 
 syntax keyword balModifiers public private external final remote const
-syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly error
+syntax keyword balTypes int byte float decimal boolean string error json xml any typedesc type future anydata handle var never readonly error
 syntax keyword balTypes function xmlns 
 syntax keyword balStructure map table stream 
 syntax keyword balTypedef type
@@ -37,22 +37,22 @@ syntax region balComment start=/\v(\/\/|#)/ skip=/\v\\./ end=/\v\_$/
 syntax match balNumber "\v<\d+>"
 syntax match balNumber "\v<\d+(.\d+)>"
 
-highlight def link balModifiers Keyword
-highlight def link balOperator Operator
-highlight def link balIs Operator
-highlight def link balTypes Type
-highlight def link balImport Identifier
-highlight def link balObject Keyword
-highlight def link balFunc Function
-highlight def link balFunctionCall Function
-highlight def link balComment Comment
-highlight def link balString String
-highlight def link balConditions Statement
-highlight def link balNumber Number
-highlight def link balStatement Statement
-highlight def link balBoolean Boolean
-highlight def link balTypedef Typedef
-highlight def link balStructure Structure
+highlight def link balModifiers     Keyword
+highlight def link balOperator      Operator
+highlight def link balIs            Operator
+highlight def link balTypes         Type
+highlight def link balImport        Identifier
+highlight def link balFunc          Function
+highlight def link balFunctionCall  Function
+highlight def link balComment       Comment
+highlight def link balString        String
+highlight def link balConditions    Statement
+highlight def link balStatement     Statement
+highlight def link balNumber        Number
+highlight def link balBoolean       Boolean
+highlight def link balTypedef       Typedef
+highlight def link balStructure     Structure
+highlight def link balObject        Structure
 
 " learn more about plugin dev - link - http://learnvimscriptthehardway.stevelosh.com/
 " learn about groups :help group-name

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -5,7 +5,8 @@ endif
 
 syntax keyword balModifiers public private external final remote const
 syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly
-syntax keyword balTypes function xml:Element xml:ProcessingInstruction xml:Comment
+syntax keyword balTypes function xmlns 
+syntax match balTypes "\v(xml|(\w*)):(Element|ProcessingInstruction|Comment)"
 syntax keyword balConditions if else while foreach for
 syntax keyword balIs is in 
 syntax keyword balImport import returns return

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -5,14 +5,15 @@ endif
 
 syntax keyword balModifiers public private external final remote const
 syntax keyword balTypes int byte float decimal boolean string error json xml any typedesc type future anydata handle var never readonly error
-syntax keyword balTypes function xmlns 
-syntax keyword balStructure map table stream 
+syntax keyword balTypes function xmlns listener service
+syntax keyword balStructure map table stream enum
 syntax keyword balTypedef type
 syntax keyword balConditions if else match
+syntax keyword balBranch continue break fork wait
 syntax keyword balRepeat while foreach
 syntax keyword balIs is in 
 syntax keyword balImport import returns
-syntax keyword balStatement return
+syntax keyword balStatement return start lock
 syntax keyword balObject object record
 syntax keyword balFunc resource worker
 syntax keyword balBoolean true false
@@ -23,7 +24,7 @@ syntax match balOperator "\v\*"
 syntax match balOperator "\v\|"
 syntax match balOperator "\v/"
 syntax match balOperator "\v\+"
-syntax match balOperator "\v-"
+syntax match balOperator "\v[^\<]-[^\>]"
 syntax match balOperator "\v\?"
 syntax match balOperator "\v\|"
 syntax match balOperator "\v\%"
@@ -35,6 +36,8 @@ syntax match balOperator "\v\+\="
 syntax match balOperator "\v-\="
 syntax match balOperator "\v\=[^\>]"
 syntax match balLabel    "\v\=\>"
+syntax match balLabel    "\v\<-"
+syntax match balLabel    "\v-\>"
 syntax region balString start=/\v"/ skip=/\v\\./ end=/\v"/
 syntax region balComment start=/\v(\/\/|#)/ skip=/\v\\./ end=/\v\_$/
 syntax match balNumber "\v<\d+>"
@@ -50,6 +53,7 @@ highlight def link balFunctionCall  Function
 highlight def link balComment       Comment
 highlight def link balString        String
 highlight def link balConditions    Conditional
+highlight def link balBranch        Conditional
 highlight def link balStatement     Statement
 highlight def link balNumber        Number
 highlight def link balFloat         Float

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -4,8 +4,9 @@ endif
 
 
 syntax keyword balModifiers public private external final remote const
-syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly
+syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly error
 syntax keyword balTypes function xmlns 
+syntax keyword balStructure map table stream 
 syntax keyword balTypedef type
 syntax keyword balConditions if else while foreach for
 syntax keyword balIs is in 
@@ -51,6 +52,7 @@ highlight def link balNumber Number
 highlight def link balStatement Statement
 highlight def link balBoolean Boolean
 highlight def link balTypedef Typedef
+highlight def link balStructure Structure
 
 " learn more about plugin dev - link - http://learnvimscriptthehardway.stevelosh.com/
 " learn about groups :help group-name

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -8,7 +8,8 @@ syntax keyword balTypes int byte float decimal boolean string error json xml any
 syntax keyword balTypes function xmlns 
 syntax keyword balStructure map table stream 
 syntax keyword balTypedef type
-syntax keyword balConditions if else while foreach for
+syntax keyword balConditions if else match
+syntax keyword balRepeat while foreach
 syntax keyword balIs is in 
 syntax keyword balImport import returns
 syntax keyword balStatement return
@@ -32,11 +33,12 @@ syntax match balOperator "\v\!\=\="
 syntax match balOperator "\v\!\="
 syntax match balOperator "\v\+\="
 syntax match balOperator "\v-\="
-syntax match balOperator "\v\="
+syntax match balOperator "\v\=[^\>]"
+syntax match balLabel    "\v\=\>"
 syntax region balString start=/\v"/ skip=/\v\\./ end=/\v"/
 syntax region balComment start=/\v(\/\/|#)/ skip=/\v\\./ end=/\v\_$/
 syntax match balNumber "\v<\d+>"
-syntax match balNumber "\v<\d+(.\d+)>"
+syntax match balFloat "\v<\d+.\d+>"
 
 highlight def link balModifiers     Keyword
 highlight def link balOperator      Operator
@@ -47,15 +49,19 @@ highlight def link balFunc          Function
 highlight def link balFunctionCall  Function
 highlight def link balComment       Comment
 highlight def link balString        String
-highlight def link balConditions    Statement
+highlight def link balConditions    Conditional
 highlight def link balStatement     Statement
 highlight def link balNumber        Number
+highlight def link balFloat         Float
 highlight def link balBoolean       Boolean
 highlight def link balTypedef       Typedef
 highlight def link balStructure     Structure
 highlight def link balObject        Structure
 highlight def link balImport        Include
 highlight def link balException     Exception
+highlight def link balRepeat        Repeat
+highlight def link balLabel         Label
+" highlight def link Todo        Todo
 
 
 " learn more about plugin dev - link - http://learnvimscriptthehardway.stevelosh.com/

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -15,6 +15,7 @@ syntax keyword balStatement return
 syntax keyword balObject object record
 syntax keyword balFunc resource worker
 syntax keyword balBoolean true false
+syntax keyword balException panic trap
 syntax match balTypes "\v(xml|(\w*)):(Element|ProcessingInstruction|Comment)"
 syntax match balFunctionCall "\zs\(\k\w*:\)*\(\k\w*\)*\s*\ze("
 syntax match balOperator "\v\*"
@@ -53,6 +54,9 @@ highlight def link balBoolean       Boolean
 highlight def link balTypedef       Typedef
 highlight def link balStructure     Structure
 highlight def link balObject        Structure
+highlight def link balImport        Include
+highlight def link balException     Exception
+
 
 " learn more about plugin dev - link - http://learnvimscriptthehardway.stevelosh.com/
 " learn about groups :help group-name

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -9,9 +9,11 @@ syntax keyword balTypes function xmlns
 syntax match balTypes "\v(xml|(\w*)):(Element|ProcessingInstruction|Comment)"
 syntax keyword balConditions if else while foreach for
 syntax keyword balIs is in 
-syntax keyword balImport import returns return
+syntax keyword balImport import returns
+syntax keyword balStatement return
 syntax keyword balObject object record
 syntax keyword balFunc resource worker
+syntax keyword balBoolean true false
 syntax match balFunctionCall "\zs\(\k\w*:\)*\(\k\w*\)*\s*\ze("
 syntax match balOperator "\v\*"
 syntax match balOperator "\v\|"
@@ -30,18 +32,23 @@ syntax match balOperator "\v-\="
 syntax match balOperator "\v\="
 syntax region balString start=/\v"/ skip=/\v\\./ end=/\v"/
 syntax region balComment start=/\v(\/\/|#)/ skip=/\v\\./ end=/\v\_$/
+syntax match balNumber "\v<\d+>"
+syntax match balNumber "\v<\d+(.\d+)>"
 
-highlight link balModifiers Keyword
-highlight link balOperator Operator
-highlight link balIs Operator
-highlight link balTypes Type
-highlight link balImport Identifier
-highlight link balObject Keyword
-highlight link balFunc Function
-highlight link balFunctionCall Function
-highlight link balComment Comment
-highlight link balString String
-highlight link balConditions Statement
+highlight def link balModifiers Keyword
+highlight def link balOperator Operator
+highlight def link balIs Operator
+highlight def link balTypes Type
+highlight def link balImport Identifier
+highlight def link balObject Keyword
+highlight def link balFunc Function
+highlight def link balFunctionCall Function
+highlight def link balComment Comment
+highlight def link balString String
+highlight def link balConditions Statement
+highlight def link balNumber Number
+highlight def link balStatement Statement
+highlight def link balBoolean Boolean
 
 " learn more about plugin dev - link - http://learnvimscriptthehardway.stevelosh.com/
 " learn about groups :help group-name

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -5,12 +5,12 @@ endif
 
 syntax keyword balModifiers public private external final remote const
 syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly
-syntax keyword balTypes function
+syntax keyword balTypes function xml:Element xml:ProcessingInstruction xml:Comment
 syntax keyword balConditions if else while foreach for
 syntax keyword balIs is in 
 syntax keyword balImport import returns return
 syntax keyword balObject object record
-syntax keyword balFunc resource worker init main
+syntax keyword balFunc resource worker
 syntax match balFunctionCall "\zs\(\k\w*:\)*\(\k\w*\)*\s*\ze("
 syntax match balOperator "\v\*"
 syntax match balOperator "\v\|"

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -5,12 +5,12 @@ endif
 
 syntax keyword balModifiers public private external final remote const const
 syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly
-syntax keyword balTypes function 
+syntax keyword balTypes function
 syntax keyword balConditions if else while foreach for
 syntax keyword balIs is in 
 syntax keyword balImport import returns return
 syntax keyword balObject object record
-syntax keyword balFunc resource worker init main
+syntax keyword balFunc resource worker init main panic
 syntax keyword balIOFunc "\vio:\*"
 syntax match balOperator "\v\*"
 syntax match balOperator "\v\|"

--- a/syntax/ballerina.vim
+++ b/syntax/ballerina.vim
@@ -3,15 +3,15 @@ if exists("b:current_syntax")
 endif
 
 
-syntax keyword balModifiers public private external final remote const const
+syntax keyword balModifiers public private external final remote const
 syntax keyword balTypes int byte float decimal boolean string error map json xml table stream any typedesc type future anydata handle var never readonly
 syntax keyword balTypes function
 syntax keyword balConditions if else while foreach for
 syntax keyword balIs is in 
 syntax keyword balImport import returns return
 syntax keyword balObject object record
-syntax keyword balFunc resource worker init main panic
-syntax keyword balIOFunc "\vio:\*"
+syntax keyword balFunc resource worker init main
+syntax region balIOFunc start=/\vio:\(/ skip=/\v\\./ end=/\v\)/
 syntax match balOperator "\v\*"
 syntax match balOperator "\v\|"
 syntax match balOperator "\v/"


### PR DESCRIPTION
# New
## Types

- never
- readonly
- service - fixes : #3
- listener
- xmlns
- xml:Element, xml:ProcessingInstruction, xml:Comment
	
<img width="259" alt="Screenshot 2020-06-07 at 04 35 38" src="https://user-images.githubusercontent.com/2173530/83956147-7030a700-a878-11ea-812d-591e1bb83627.png">

- enum
- true false (`highlight def link balBoolean Boolean`)

## Statements
- lock
- fork
- wait
- match
- function call statement

## Labels
- worker receive/send actions `<-`, `->`
- match expressions operator `=>`

<img width="431" alt="Screenshot 2020-06-07 at 04 33 18" src="https://user-images.githubusercontent.com/2173530/83956101-129c5a80-a878-11ea-9609-cfe1fb76998a.png">


# Number highlights
- now we highligh simple literal numbers and float values
<img width="212" alt="Screenshot 2020-06-07 at 04 31 44" src="https://user-images.githubusercontent.com/2173530/83956089-d7019080-a877-11ea-9c99-44d7133b855d.png">


# Removals
## Statements
- for